### PR TITLE
feat!: updates var defaults per #8

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -49,31 +49,31 @@ variable "logging_retention" {
 
 variable "copy_paste_enabled" {
   description = "(Optional) refer to resource provider for usage"
-  default     = null
+  default     = true
   type        = bool
 }
 
 variable "file_copy_enabled" {
   description = "(Optional) refer to resource provider for usage"
-  default     = null
+  default     = false
   type        = bool
 }
 
 variable "ip_connect_enabled" {
   description = "(Optional) refer to resource provider for usage"
-  default     = null
+  default     = false
   type        = bool
 }
 
 variable "shareable_link_enabled" {
   description = "(Optional) refer to resource provider for usage"
-  default     = null
+  default     = false
   type        = bool
 }
 
 variable "tunneling_enabled" {
   description = "(Optional) refer to resource provider for usage"
-  default     = null
+  default     = true
   type        = bool
 }
 


### PR DESCRIPTION
Updates the following var defaults: 

- copy_paste_enabled: true
- tunneling_enabled: true (enable connection via native client)
- file_copy_enabled: false
- ip_connect_enabled: false (used for on-premises connections)
- shareable_link_enabled: false

BREAKING CHANGE: If you were not previously providing values for these variables, these new defaults may result in unexpected behavior. 